### PR TITLE
Render event names on gift and promo card previews

### DIFF
--- a/viator_card_customizer_v5.html
+++ b/viator_card_customizer_v5.html
@@ -332,13 +332,25 @@ function drawGC(ctx, v, W, H) {
   // "GIFT CERTIFICATE"
   txt(ctx, "GIFT CERTIFICATE", cx, boxT+148, 64, "800", "#ffffff", "center");
 
+  // Event name (auto-scales to fit green box)
+  const eventName = v.gn ? v.gn.trim() : "";
+  if (eventName) {
+    let eventSize = 56;
+    ctx.font = "700 " + eventSize + "px Inter,sans-serif";
+    while (ctx.measureText(eventName).width > (boxR - boxL - pad * 2) && eventSize > 34) {
+      eventSize -= 2;
+      ctx.font = "700 " + eventSize + "px Inter,sans-serif";
+    }
+    txt(ctx, eventName, cx, boxT + 225, eventSize, "700", "rgba(255,255,255,0.95)", "center");
+  }
+
   // Dollar amount — big centered
   const amt = v.ga ? "$" + v.ga : "";
   if (amt) {
-    txt(ctx, amt, cx, boxT+330, 200, "900", "#ffffff", "center");
+    txt(ctx, amt, cx, boxT+350, 200, "900", "#ffffff", "center");
   } else {
     // placeholder ghost
-    txt(ctx, "$", cx, boxT+330, 200, "900", "rgba(255,255,255,0.15)", "center");
+    txt(ctx, "$", cx, boxT+350, 200, "900", "rgba(255,255,255,0.15)", "center");
   }
 
   // Promo code section
@@ -384,6 +396,18 @@ function drawGC(ctx, v, W, H) {
 
 function drawPC(ctx, v, W, H) {
   const cx = W / 2;
+
+  // Event name headline at top
+  const eventName = v.pn ? v.pn.trim() : "";
+  if (eventName) {
+    let eventSize = 74;
+    ctx.font = "800 " + eventSize + "px Inter,sans-serif";
+    while (ctx.measureText(eventName).width > W - 150 && eventSize > 42) {
+      eventSize -= 2;
+      ctx.font = "800 " + eventSize + "px Inter,sans-serif";
+    }
+    txt(ctx, eventName.toUpperCase(), cx, 175, eventSize, "800", "#ffffff", "center");
+  }
 
   // Auto-format discount: "10" → "10% OFF", "10% OFF" → "10% OFF"
   const rawDisc = v.pd ? v.pd.trim() : "";


### PR DESCRIPTION
### Motivation
- Make the card preview more informative by rendering the `Event Name` field visibly on both Gift Certificate and Promo Card previews.
- Prevent long event names from overflowing the design by auto-scaling text to fit available space.
- Preserve visual spacing in the Gift Certificate layout after adding the event-line.

### Description
- Added event-name rendering to `drawGC` with a font-size downscaling loop so `Event Name` appears centered within the green voucher box (file: `viator_card_customizer_v5.html`).
- Shifted the Gift Certificate dollar amount baseline slightly downward to preserve spacing after inserting the event name line.
- Added an uppercase, auto-scaling event-name headline to `drawPC` so promo card previews display the `Event Name` consistently and without overflow.
- All sizing uses `ctx.measureText()` in a loop to reduce font size until the text fits the available width.

### Testing
- Started a local server with `python3 -m http.server 8000` and verified the page served successfully. (succeeded)
- Exercised the interactive preview via a Playwright script that fills fields and captures screenshots, producing a screenshot artifact (`artifacts/viator-page.png`). (succeeded after initial timeouts)
- Render and layout changes were inspected by loading the page and verifying that event names render and scale correctly in both card modes. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a85c57b91483329074d364ecc09339)